### PR TITLE
Use correct crate-type in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [lib]
 name = "client_lib"
 path = "src/lib.rs"
-# crate-type = ["staticlib", "cdylib"]
+crate-type = ["staticlib", "cdylib", "lib"]
 
 [[bin]]
 name = "cli"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # New york city
+
 A TSS plugin for mobile wallet
 
 ## Check below instructions to use
@@ -8,3 +9,13 @@ A TSS plugin for mobile wallet
 [How to test](./TEST.md)
 
 [How to build](./BUILD.md)
+
+## Build Rust
+
+```bash
+# building the library only
+cargo build --lib --release
+
+# building the library AND the cli binary
+cargo build --release
+```

--- a/makefile
+++ b/makefile
@@ -39,9 +39,9 @@ all: ios android
 # macos bindings
 
 ## ios: Compile the iOS universal library
-ios: target/universal/release/libexample.a
+ios: target/universal/release/libclient_lib.a
 
-target/universal/release/libexample.a: $(SOURCES) ndk-home
+target/universal/release/libclient_lib.a: $(SOURCES) ndk-home
 	@if [ $$(uname) == "Darwin" ] ; then \
 		cargo lipo --release ; \
 		else echo "Skipping iOS compilation on $$(uname)" ; \
@@ -49,16 +49,16 @@ target/universal/release/libexample.a: $(SOURCES) ndk-home
 	@echo "[DONE] $@"
 
 ## macos: Compile the macOS libraries
-macos: target/x86_64-apple-darwin/release/libexample.dylib target/aarch64-apple-darwin/release/libexample.dylib
+macos: target/x86_64-apple-darwin/release/libclient_lib.dylib target/aarch64-apple-darwin/release/libclient_lib.dylib
 
-target/x86_64-apple-darwin/release/libexample.dylib: $(SOURCES)
+target/x86_64-apple-darwin/release/libclient_lib.dylib: $(SOURCES)
 	@if [ $$(uname) == "Darwin" ] ; then \
 		cargo lipo --release --targets x86_64-apple-darwin ; \
 		else echo "Skipping macOS compilation on $$(uname)" ; \
 	fi
 	@echo "[DONE] $@"
 
-target/aarch64-apple-darwin/release/libexample.dylib: $(SOURCES)
+target/aarch64-apple-darwin/release/libclient_lib.dylib: $(SOURCES)
 	@if [ $$(uname) == "Darwin" ] ; then \
 		cargo lipo --release --targets aarch64-apple-darwin ; \
 		else echo "Skipping macOS compilation on $$(uname)" ; \
@@ -66,27 +66,27 @@ target/aarch64-apple-darwin/release/libexample.dylib: $(SOURCES)
 	@echo "[DONE] $@"
 
 ## android: Compile the android targets (arm64, armv7 and i686)
-android: target/aarch64-linux-android/release/libexample.so target/armv7-linux-androideabi/release/libexample.so target/i686-linux-android/release/libexample.so target/x86_64-linux-android/release/libexample.so
+android: target/aarch64-linux-android/release/libclient_lib.so target/armv7-linux-androideabi/release/libclient_lib.so target/i686-linux-android/release/libclient_lib.so target/x86_64-linux-android/release/libclient_lib.so
 
-target/aarch64-linux-android/release/libexample.so: $(SOURCES) ndk-home
+target/aarch64-linux-android/release/libclient_lib.so: $(SOURCES) ndk-home
 	CC_aarch64_linux_android=$(ANDROID_AARCH64_LINKER) \
 	CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=$(ANDROID_AARCH64_LINKER) \
 		cargo build --target aarch64-linux-android --release
 	@echo "[DONE] $@"
 
-target/armv7-linux-androideabi/release/libexample.so: $(SOURCES) ndk-home
+target/armv7-linux-androideabi/release/libclient_lib.so: $(SOURCES) ndk-home
 	CC_armv7_linux_androideabi=$(ANDROID_ARMV7_LINKER) \
 	CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=$(ANDROID_ARMV7_LINKER) \
 		cargo build --target armv7-linux-androideabi --release
 	@echo "[DONE] $@"
 
-target/i686-linux-android/release/libexample.so: $(SOURCES) ndk-home
+target/i686-linux-android/release/libclient_lib.so: $(SOURCES) ndk-home
 	CC_i686_linux_android=$(ANDROID_I686_LINKER) \
 	CARGO_TARGET_I686_LINUX_ANDROID_LINKER=$(ANDROID_I686_LINKER) \
 		cargo  build --target i686-linux-android --release
 	@echo "[DONE] $@"
 
-target/x86_64-linux-android/release/libexample.so: $(SOURCES) ndk-home
+target/x86_64-linux-android/release/libclient_lib.so: $(SOURCES) ndk-home
 	CC_x86_64_linux_android=$(ANDROID_X86_64_LINKER) \
 	CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=$(ANDROID_X86_64_LINKER) \
 		cargo build --target x86_64-linux-android --release


### PR DESCRIPTION
By specifying the `crate-type` correctly, we can support lib.rs rust build as a rust lib, an iOS lib and an Android lib